### PR TITLE
Add Gauge metric encoding support

### DIFF
--- a/modules/metrics-circe/src/test/scala/io/tabmo/metrics/circe/CirceMetricsEncoderSpec.scala
+++ b/modules/metrics-circe/src/test/scala/io/tabmo/metrics/circe/CirceMetricsEncoderSpec.scala
@@ -11,8 +11,11 @@ class CirceMetricsEncoderSpec extends FlatSpec with Matchers {
       countCounter <- tested.hcursor.downField("metrics.test.the.counter").downField("count").as[Long].right
       countTimer <- tested.hcursor.downField("metrics.test.the.timer").downField("count").as[Long].right
       countMeter <- tested.hcursor.downField("metrics.test.the.meter").downField("count").as[Long].right
-    } yield (countCounter, countTimer, countMeter)
+      longGauge <- tested.hcursor.downField("metrics.test.the.gauge.long").as[Long].right
+      floatGauge <- tested.hcursor.downField("metrics.test.the.gauge.float").as[Float].right
+      stringGauge <- tested.hcursor.downField("metrics.test.the.gauge.string").as[String].right
+    } yield (countCounter, countTimer, countMeter, longGauge, floatGauge, stringGauge)
 
-    result.right.get should be equals((16L, 0L, 1L))
+    result.right.get should be equals((16L, 0L, 1L, 42l, 42.42f, "42"))
   }
 }

--- a/modules/metrics-circe/src/test/scala/io/tabmo/metrics/circe/test.scala
+++ b/modules/metrics-circe/src/test/scala/io/tabmo/metrics/circe/test.scala
@@ -6,4 +6,7 @@ object test extends DefaultInstrumented {
   metrics.counter("the.counter").inc(16)
   metrics.timer("the.timer")
   metrics.meter("the.meter").mark()
+  metrics.gauge[Long]("the.gauge.long"){42l}
+  metrics.gauge[Float]("the.gauge.float"){42.42f}
+  metrics.gauge[String]("the.gauge.string"){"42"}
 }

--- a/modules/metrics-playjson/src/main/scala/io/tabmo/metrics/playjson/PlayJsonMetricsEncoder.scala
+++ b/modules/metrics-playjson/src/main/scala/io/tabmo/metrics/playjson/PlayJsonMetricsEncoder.scala
@@ -61,11 +61,26 @@ trait PlayJsonMetricsEncoder {
     )
   }
 
+  implicit def gaugeEncoder: Writes[Gauge[_]] = Writes { gauge =>
+    gauge.getValue match {
+      case x: Int => JsNumber(x)
+      case x: Long => JsNumber(x)
+      case x: Float => JsNumber(x.toDouble)
+      case x: Double => JsNumber(x)
+      case x: BigDecimal => JsNumber(x)
+      case x: BigInt => JsNumber(BigDecimal(x))
+      case x: Boolean => JsBoolean(x)
+      case x: String => JsString(x)
+      case _ => JsString(gauge.getValue.toString)
+    }
+  }
+
   implicit val metricRegisterEncoder: Writes[MetricRegistry] = Writes[MetricRegistry] { metrics =>
     def encode(key: String, metric: Metric) = metric match {
       case m: Meter => Json.obj(key -> m)
       case t: Timer => Json.obj(key -> t)
       case c: Counter => Json.obj(key -> c)
+      case g: Gauge[_] => Json.obj(key -> g)
       case _ => Json.obj()
     }
 

--- a/modules/metrics-playjson/src/test/scala/io/tabmo/metrics/playjson/PlayJsonMetricsEncoderSpec.scala
+++ b/modules/metrics-playjson/src/test/scala/io/tabmo/metrics/playjson/PlayJsonMetricsEncoderSpec.scala
@@ -13,5 +13,9 @@ class PlayJsonMetricsEncoderSpec extends FlatSpec with Matchers {
     (tested \ "metrics.test.the.counter" \ "count").as[Long] shouldEqual 16L
     (tested \ "metrics.test.the.timer" \ "count").as[Long] shouldEqual 0L
     (tested \ "metrics.test.the.meter" \ "count").as[Long] shouldEqual 1L
+
+    (tested \ "metrics.test.the.gauge.long").as[Long] shouldEqual 42l
+    (tested \ "metrics.test.the.gauge.float").as[BigDecimal] shouldEqual BigDecimal(42.42)
+    (tested \ "metrics.test.the.gauge.string").as[String] shouldEqual "42"
   }
 }

--- a/modules/metrics-playjson/src/test/scala/io/tabmo/metrics/playjson/test.scala
+++ b/modules/metrics-playjson/src/test/scala/io/tabmo/metrics/playjson/test.scala
@@ -6,4 +6,7 @@ object test extends DefaultInstrumented {
   metrics.counter("the.counter").inc(16)
   metrics.timer("the.timer")
   metrics.meter("the.meter").mark()
+  metrics.gauge[Long]("the.gauge.long"){42l}
+  metrics.gauge[BigDecimal]("the.gauge.float"){42.42}
+  metrics.gauge[String]("the.gauge.string"){"42"}
 }


### PR DESCRIPTION
Not really great, didn't found a prettier way to encode generics wrapped into Gauge.
I tried something like : 
```
implicit def gaugeEncoder[T](implicit enc: Encoder[T]): Encoder[Gauge[T]] = Encoder.instance { gauge =>
    enc(gauge.getValue)
}
```
bot did not works :(